### PR TITLE
fix: keep rholang code in sync with action, fields

### DIFF
--- a/src/participate.html
+++ b/src/participate.html
@@ -66,12 +66,7 @@
     </form>
     <p>idea: show avatars for members; give emoji kudos <a href="https://emojipedia.org/red-heart/">❤️</a></p>
     <h3>ToDo</h3>
-    <ul>
-      <li>handle multiple deploys concurrently</li>
-      <li>"insert 25cents to play" account rather than in-your-face signature at each move</li>
-      <li>push more of the actions down into deployed contracts</li>
-      <li>provide access to #define bindings in actions</li>
-    </ul>
+    <p><em>See <a href="https://github.com/rchain-community/rgov/issues">rgov issues</a></em></p>
     <div id="groupControl">
       <h3>Members...</h3>
     </div>
@@ -83,8 +78,6 @@
     and the <a href="https://github.com/rchain-community/">RChain Community</a>
   </address>
 
-  <h3>ToDo</h3>
-  <p><em>See <a href="https://github.com/rchain-community/rgov/issues">rgov issues</a></em></p>
 </body>
 
 </html>


### PR DESCRIPTION
_didn't mean to close #88_

`setFields` was `async` but we weren't `await`ing its results, so the
Deploy button could be hit before the rholang term textarea was
updated.

  - fetch rholang source when action is changed, not each time
    a field value is changed
    - set action() accessor method -> async setAction()
    - state.term type includes null because it's not available while
      we're fetching rholang source
    - go busy() while fetching rholang source
  - makeBusy: replace ambient access to redraw with explicit arg
  - buildUI uses busy() rather than redraw()

fixes: #57

builds on #84; once that's merged, this should target the `master` branch.
