### PR TITLE
fixed space in directory during restore snapshot

### DIFF
--- a/bootstrap/restore-snapshot
+++ b/bootstrap/restore-snapshot
@@ -17,8 +17,9 @@ if [ $? -ne 0 ] ; then exit $?; fi
 
 TARGET=$PWD/snapshot/$1.tgz
 
-if [ -f $TARGET ];then
-   (cd ~; tar xzf $TARGET) && echo "snapshot restored: $TARGET"
+echo $TARGET TARGET
+if [ -f "$TARGET" ];then
+   (cd ~; tar xzf "$TARGET") && echo "snapshot restored: $TARGET"
 else
    echo "snapshot not found: $TARGET"
 fi


### PR DESCRIPTION
A [similar problem](https://github.com/rchain-community/rgov/pull/172) that @jimscarver and I fixed in ```create-snapshot``` exists in ```restore-snapshot```, A spaced directory such as ```Web Projects``` causes the script to run the directory as separate arguments leading to error