### PR TITLE
Fix vscode workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ dist/
 yarn.lock
 ReadcapURI.json
 testing/unit_test/__pycache__
+**/.pytest_cache
+**/__pycache__

--- a/liquid-democracy.code-workspace
+++ b/liquid-democracy.code-workspace
@@ -12,7 +12,9 @@
 		"files.watcherExclude": {
 			"**/bootstrap/rchain": true,
 			"**/dist": true,
-			"node_modules": true
+			"node_modules": true,
+			"**/.pytest_cache": true,
+			"**/__pycachge_": true,
 		}
 	}
 }


### PR DESCRIPTION
This branch is not well-named.
Update the vscode workspace to exclude python testing workfiles.